### PR TITLE
Auto-mounting the service log directory.

### DIFF
--- a/lib/armada/docker/container.rb
+++ b/lib/armada/docker/container.rb
@@ -9,6 +9,10 @@ module Armada
       @name        = options[:container_name]
       @container   = docker_host.get_container(@name)
       @options     = options
+
+      now_in_ns = Integer(Time.now.to_f * 1000000.0)
+      @options[:binds] ||= []
+      @options[:binds] << "/var/log/#{@name}-#{now_in_ns}:/var/log/service"
     end
 
     def stop

--- a/spec/docker/container_spec.rb
+++ b/spec/docker/container_spec.rb
@@ -28,6 +28,16 @@ describe Armada::Container do
     :host_config => { "StartConfigKey" => "StartConfigValue" },
   }}
 
+  describe "#initialize" do
+    before { armada_container }
+
+    it "should have the log mount" do
+      expect(options[:binds]).not_to be_nil
+      expect(options[:binds].length).to equal 1
+      expect(options[:binds][0]).to match /^\/var\/log\/#{container_name}-\d+:\/var\/log\/service$/
+    end
+  end
+
   describe "#stop" do
     context "when the container exists" do
       before { docker_host.should_receive(:get_container).and_return(docker_container) }
@@ -110,7 +120,7 @@ describe Armada::Container do
     it { should include("name"         => "some_container") }
     it { should include("ExposedPorts" => { "1111/tcp" => {}, "2222/udp" => {}}) }
     it { should include("Env"          => ["KEY=VALUE", "HOST=hostname"]) }
-    it { should include("Volumes"      => { "/container/log" => {}}) }
+    it { should include("Volumes"      => { "/container/log" => {} }) }
     it { should include("VolumesFrom"  => "parent") }
     it { should include("RestartPolicy" => { "MaximumRetryCount" => 5, "Name" => "always" }) }
     it { should include("CreateConfigKey" => "CreateConfigValue") }


### PR DESCRIPTION
Mounts /var/log/service in the container to /var/log/<image-name>-<time-in-ns> on the host.

This allows us to simply point the splunk forwarder to /var/log on the host so that we get all of the logs for the host and all running containers automatically.